### PR TITLE
Refactor job registry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "react-markdown": "^10.1.0",
         "rehype-katex": "^7.0.1",
         "remark-math": "^6.0.0",
+        "rxjs": "^7.8.2",
         "tailwindcss": "^4.1.16",
         "zod": "^4.1.12"
       },
@@ -37,7 +38,8 @@
         "prettier": "^3.6.2",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.45.0",
-        "vite": "^7.1.7"
+        "vite": "^7.1.7",
+        "vitest": "^4.0.12"
       }
     },
     "node_modules/@ai-sdk/gateway": {
@@ -1773,6 +1775,17 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -1781,6 +1794,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2176,6 +2196,117 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.12.tgz",
+      "integrity": "sha512-is+g0w8V3/ZhRNrRizrJNr8PFQKwYmctWlU4qg8zy5r9aIV5w8IxXLlfbbxJCwSpsVl2PXPTm2/zruqTqz3QSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.12",
+        "@vitest/utils": "4.0.12",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.12.tgz",
+      "integrity": "sha512-GsmA/tD5Ht3RUFoz41mZsMU1AXch3lhmgbTnoSPTdH231g7S3ytNN1aU0bZDSyxWs8WA7KDyMPD5L4q6V6vj9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.12",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.12.tgz",
+      "integrity": "sha512-R7nMAcnienG17MvRN8TPMJiCG8rrZJblV9mhT7oMFdBXvS0x+QD6S1G4DxFusR2E0QIS73f7DqSR1n87rrmE+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.12.tgz",
+      "integrity": "sha512-hDlCIJWuwlcLumfukPsNfPDOJokTv79hnOlf11V+n7E14rHNPz0Sp/BO6h8sh9qw4/UjZiKyYpVxK2ZNi+3ceQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.12",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.12.tgz",
+      "integrity": "sha512-2jz9zAuBDUSbnfyixnyOd1S2YDBrZO23rt1bicAb6MA/ya5rHdKFRikPIDpBj/Dwvh6cbImDmudegnDAkHvmRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.12",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.12.tgz",
+      "integrity": "sha512-GZjI9PPhiOYNX8Nsyqdw7JQB+u0BptL5fSnXiottAUBHlcMzgADV58A7SLTXXQwcN1yZ6gfd1DH+2bqjuUlCzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.12.tgz",
+      "integrity": "sha512-DVS/TLkLdvGvj1avRy0LSmKfrcI9MNFvNGN6ECjTUHWJdlcgPDOXhjMis5Dh7rBH62nAmSXnkPbE+DZ5YD75Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.12",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -2256,6 +2387,16 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/bail": {
       "version": "2.0.2",
@@ -2381,6 +2522,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.1.tgz",
+      "integrity": "sha512-p4Z49OGG5W/WBCPSS/dH3jQ73kD6tiMmUM+bckNK6Jr5JHMG3k9bg/BvKR8lKmtVBKmOiuVaV2ws8s9oSbwysg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -2639,6 +2790,13 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.25.11",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.11.tgz",
@@ -2880,6 +3038,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2903,6 +3071,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
+      "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/extend": {
@@ -4727,6 +4905,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5062,6 +5247,15 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -5101,6 +5295,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/snake-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
@@ -5129,6 +5330,20 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
@@ -5207,6 +5422,20 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -5250,6 +5479,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -5672,6 +5911,101 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.12.tgz",
+      "integrity": "sha512-pmW4GCKQ8t5Ko1jYjC3SqOr7TUKN7uHOHB/XGsAIb69eYu6d1ionGSsb5H9chmPf+WeXt0VE7jTXsB1IvWoNbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.12",
+        "@vitest/mocker": "4.0.12",
+        "@vitest/pretty-format": "4.0.12",
+        "@vitest/runner": "4.0.12",
+        "@vitest/snapshot": "4.0.12",
+        "@vitest/spy": "4.0.12",
+        "@vitest/utils": "4.0.12",
+        "debug": "^4.4.3",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.12",
+        "@vitest/browser-preview": "4.0.12",
+        "@vitest/browser-webdriverio": "4.0.12",
+        "@vitest/ui": "4.0.12",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
@@ -5696,6 +6030,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "vitest"
   },
   "dependencies": {
     "@ai-sdk/openai": "^2.0.53",
@@ -25,6 +26,7 @@
     "react-markdown": "^10.1.0",
     "rehype-katex": "^7.0.1",
     "remark-math": "^6.0.0",
+    "rxjs": "^7.8.2",
     "tailwindcss": "^4.1.16",
     "zod": "^4.1.12"
   },
@@ -41,6 +43,7 @@
     "prettier": "^3.6.2",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.45.0",
-    "vite": "^7.1.7"
+    "vite": "^7.1.7",
+    "vitest": "^4.0.12"
   }
 }

--- a/src/App/ChatHistoryView.tsx
+++ b/src/App/ChatHistoryView.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { getAllChatThreads, type PageType } from "../services/querier";
-import { categorizeDateByPeriod, type TimePeriod } from "../utils";
+import { categorizeDateByPeriod, type TimePeriod } from "../utils/utils";
 import { onRouteChanged } from "../services/route-change-service";
 
 interface ChatHistoryViewProps {

--- a/src/App/NewChatView.tsx
+++ b/src/App/NewChatView.tsx
@@ -6,12 +6,9 @@ import {
   type Message,
   searchPagesByName,
 } from "../services/querier";
-import {
-  spawnCompletionJobForPage,
-  subscribeToCompletionJobs,
-  cancelCompletionJob,
-} from "../services/chat-completion";
-import { transformDashBulletPointsToStars } from "../utils";
+import { completionTaskRunnerRepository } from "../services/completion-task-runners";
+import { simpleCompletion } from "../services/chat-completion-tasks";
+import { transformDashBulletPointsToStars } from "../utils/utils";
 
 interface NewChatViewProps {
   onThreadCreated: (pageId: string) => void;
@@ -20,22 +17,18 @@ interface NewChatViewProps {
 export function NewChatView({ onThreadCreated }: NewChatViewProps) {
   const [hasRunningJob, setHasRunningJob] = useState(false);
   const runningPagesRef = useRef<Set<string>>(new Set());
+  const unsubscribeRef = useRef<Map<string, () => void>>(new Map());
 
   useEffect(() => {
+    const unsubscribeMap = unsubscribeRef.current;
     const runningPages = runningPagesRef.current;
-    const unsubscribe = subscribeToCompletionJobs((pageId, status) => {
-      if (status.state === "running") {
-        runningPages.add(pageId);
-      } else {
-        runningPages.delete(pageId);
-      }
-      setHasRunningJob(runningPages.size > 0);
-    });
 
     return () => {
+      // Cleanup all listeners on unmount
+      unsubscribeMap.forEach((unsubscribe) => unsubscribe());
+      unsubscribeMap.clear();
       runningPages.clear();
       setHasRunningJob(false);
-      unsubscribe();
     };
   }, []);
 
@@ -56,23 +49,50 @@ export function NewChatView({ onThreadCreated }: NewChatViewProps) {
         content: currentInput,
       } as Message);
 
-      runningPagesRef.current.add(pageId);
-      setHasRunningJob(true);
+      // Set up listener for this page
+      const unsubscribe = completionTaskRunnerRepository.listen(
+        pageId,
+        (state) => {
+          const runningPages = runningPagesRef.current;
+          if (state.type === "running") {
+            runningPages.add(pageId);
+          } else {
+            runningPages.delete(pageId);
+            // Clean up listener when job completes
+            const unsub = unsubscribeRef.current.get(pageId);
+            if (unsub) {
+              unsub();
+              unsubscribeRef.current.delete(pageId);
+            }
+          }
+          setHasRunningJob(runningPages.size > 0);
+        }
+      );
+      unsubscribeRef.current.set(pageId, unsubscribe);
 
       // Spawn completion job for assistant reply (no prior messages for new chat)
-      const startPromise = spawnCompletionJobForPage(pageId, {
-        input: transformDashBulletPointsToStars(currentInput),
-        messages: [],
-      }).catch((error) => {
+      try {
+        const stateNode =
+          completionTaskRunnerRepository.getTaskRunnerStateNode(pageId);
+        if (stateNode.type === "idle") {
+          stateNode.run(
+            simpleCompletion(transformDashBulletPointsToStars(currentInput), [])
+          );
+        }
+      } catch (error) {
         console.error("Failed to start assistant reply.", error);
         logseq.UI.showMsg("Failed to start assistant reply.", "error");
         runningPagesRef.current.delete(pageId);
         setHasRunningJob(runningPagesRef.current.size > 0);
-      });
+        const unsub = unsubscribeRef.current.get(pageId);
+        if (unsub) {
+          unsub();
+          unsubscribeRef.current.delete(pageId);
+        }
+      }
 
       // Transition to CHAT_THREAD view
       onThreadCreated(pageId);
-      await startPromise;
     } catch (e) {
       logseq.UI.showMsg(`${e ?? ""}`, "error");
     }
@@ -91,7 +111,11 @@ export function NewChatView({ onThreadCreated }: NewChatViewProps) {
         onCancel={() => {
           const runningPages = Array.from(runningPagesRef.current);
           for (const pageId of runningPages) {
-            cancelCompletionJob(pageId);
+            const stateNode =
+              completionTaskRunnerRepository.getTaskRunnerStateNode(pageId);
+            if (stateNode.type === "running") {
+              stateNode.stop();
+            }
           }
         }}
         searchPage={searchPagesByName}

--- a/src/App/components/MessageList/MessageList.tsx
+++ b/src/App/components/MessageList/MessageList.tsx
@@ -3,7 +3,7 @@ import ReactMarkdown from "react-markdown";
 import remarkMath from "remark-math";
 import rehypeKatex from "rehype-katex";
 import "katex/dist/katex.min.css";
-import { filterPropertyLines } from "../../../utils";
+import { filterPropertyLines } from "../../../utils/utils";
 import type { BlockMessage } from "../../../services/querier";
 import type { Components } from "react-markdown";
 import { remarkLogseqPageRefs } from "./remark-logseq-page-refs";

--- a/src/architecture.md
+++ b/src/architecture.md
@@ -1,0 +1,91 @@
+# Architecture
+
+We have a repository of agents.
+
+```typescript
+type RunningState = { type: "streaming" };
+
+export const runnerRepository = createTaskRunnerRepository<
+  string,
+  RunningState
+>();
+```
+
+An initialized task runner repository will always be a singleton service that gets imported and used.
+
+A task runner repository has multiple task runners, each associated with a key. Each task runner can run at most one task.
+
+For this reason, a task runner actually doesn't allow running any tasks without proper checks and balances, and we leverage TypeScript's type system for enforcing that (not perfect; future work is needed to ensure read-only and write-only locks).
+
+```typescript
+const stateNode = runnerRepository.getTaskRunnerStateNode(key);
+
+// TypeScript will raise a compiler error if we attempt to invoke
+// directly`job.start`. We first need to see if it's idle and ready.
+if (stateNode.type === "idle") {
+  stateNode.run(task);
+}
+```
+
+Jobs can also be stopped.
+
+```typescript
+if (stateNode.type === "running") {
+  stateNode.stop();
+
+  // If the reason to stop is because there was an error, then a parameter can
+  // be passed
+  //
+  // job.stop(new Error('An error occurred'));
+}
+```
+
+A task has the following signature:
+
+```typescript
+type Task<JobKey, RunningState> = ({
+  jobKey: JobKey,
+  abortSignal: AbortSignal,
+}) => Observable<RunningState>;
+```
+
+We can also listen to state changes.
+
+For example:
+
+```typescript
+runnerRepository.listen(key, (state) => {
+  // State is either an Idle state or Running<unknown> state.
+});
+```
+
+## TaskRunnerRepository
+
+Here is the dependency graph of it all.
+
+```mermaid
+graph TD
+    A["createTaskRunnerRepository<br/>(task-runner-repository.ts)"] --> B["pubSub<br/>(pub-sub/pub-sub.ts)"]
+    A --> C["pubSubRegistry<br/>(pub-sub/pub-sub.ts)"]
+    A --> D["firstFromSubjectSync<br/>(subject/subject.ts)"]
+
+    B --> E["resourceRegistry<br/>(resource-registry/resource-registry.ts)"]
+
+    C --> E
+    C --> F["subject<br/>(subject/subject.ts)"]
+
+    D --> F
+
+    E --> G["Map<br/>(native JS)"]
+
+    F --> H["Set<br/>(native JS)"]
+
+    style A fill:#e1f5ff,stroke:#01579b,stroke-width:3px
+    style B fill:#fff3e0,stroke:#e65100
+    style C fill:#fff3e0,stroke:#e65100
+    style D fill:#f3e5f5,stroke:#4a148c
+    style E fill:#e8f5e9,stroke:#1b5e20
+    style F fill:#f3e5f5,stroke:#4a148c
+    style G fill:#f5f5f5,stroke:#424242
+    style H fill:#f5f5f5,stroke:#424242
+```

--- a/src/services/agent-orchestrator.ts
+++ b/src/services/agent-orchestrator.ts
@@ -1,3 +1,5 @@
+// TODO: perhaps get rid of this.
+
 import { createOpenAI } from "@ai-sdk/openai";
 import { generateObject } from "ai";
 import { z } from "zod";

--- a/src/services/chat-completion-tasks.ts
+++ b/src/services/chat-completion-tasks.ts
@@ -1,0 +1,38 @@
+import { type Task } from "../utils/task-runner-repository/task-runner-repository";
+import type { Message } from "./querier";
+import { runCompletion } from "./chat-completion";
+import { transformDashBulletPointsToStars } from "../utils/utils";
+import { from } from "rxjs";
+import type { JobKey, RunningState } from "./completion-task-runners";
+
+export const simpleCompletion: (
+  input: string,
+  messages: Message[]
+) => Task<JobKey, RunningState> =
+  (input, messages) =>
+  ({ jobKey, abortSignal }) => {
+    return from(
+      (async function* fn(): AsyncIterable<RunningState> {
+        const stream = await runCompletion({
+          input,
+          messages,
+          signal: abortSignal,
+        });
+
+        yield { type: "streaming" };
+
+        let content = "role:: assistant\n";
+        const block = await logseq.Editor.appendBlockInPage(jobKey, content);
+        if (!block?.uuid) throw new Error("Failed to append block");
+
+        for await (const chunk of stream) {
+          if (abortSignal.aborted) return;
+          content += chunk;
+          await logseq.Editor.updateBlock(
+            block.uuid,
+            transformDashBulletPointsToStars(content)
+          );
+        }
+      })()
+    );
+  };

--- a/src/services/completion-task-runners.ts
+++ b/src/services/completion-task-runners.ts
@@ -1,0 +1,9 @@
+import { createTaskRunnerRepository } from "../utils/task-runner-repository/task-runner-repository";
+
+export type JobKey = string;
+export type RunningState = { type: "streaming" };
+
+export const completionTaskRunnerRepository = createTaskRunnerRepository<
+  JobKey,
+  RunningState
+>();

--- a/src/services/job-registry.ts
+++ b/src/services/job-registry.ts
@@ -1,5 +1,7 @@
 import type { Message } from "./querier";
-import { transformDashBulletPointsToStars } from "../utils";
+import { transformDashBulletPointsToStars } from "../utils/utils";
+
+// TODO: get rid of this.
 
 // jobRegistry.ts
 export type JobStatus =

--- a/src/services/querier.ts
+++ b/src/services/querier.ts
@@ -1,5 +1,8 @@
+// TODO: this should really be in some "helpers" folder of something of that
+//   sort.
+
 import { z } from "zod";
-import { filterPropertyLines } from "../utils";
+import { filterPropertyLines } from "../utils/utils";
 import type { BlockEntity } from "@logseq/libs/dist/LSPlugin.user";
 
 // Note: this comment on GitHub helped a lot:

--- a/src/services/ready-service.ts
+++ b/src/services/ready-service.ts
@@ -1,4 +1,4 @@
-import { gate } from "../utils";
+import { gate } from "../utils/utils";
 
 const readyGate = gate();
 

--- a/src/services/route-change-service.ts
+++ b/src/services/route-change-service.ts
@@ -1,5 +1,5 @@
+import { subject } from "../utils/subject/subject";
 import { onReady } from "./ready-service";
-import { subject } from "../utils";
 
 const routeChangedSubject = subject<void>();
 

--- a/src/utils/pub-sub/pub-sub.test.ts
+++ b/src/utils/pub-sub/pub-sub.test.ts
@@ -1,0 +1,757 @@
+import { expect, should, test, vi } from "vitest";
+import { pubSub, pubSubRegistry } from "./pub-sub";
+
+// Tests for pubSubRegistry
+test("pubSubRegistry basic allocation returns subject and lastValueEmitted", () => {
+  const registry = pubSubRegistry<string, string>();
+
+  expect(registry.isAllocated("foo")).toBe(false);
+
+  const value = registry.allocate("foo");
+
+  expect(registry.isAllocated("foo")).toBe(true);
+  expect(value).toHaveProperty("subject");
+  expect(value).toHaveProperty("lastValueEmitted");
+  expect(value.lastValueEmitted).toBe(null);
+  expect(value.subject).toHaveProperty("listen");
+  expect(value.subject).toHaveProperty("next");
+});
+
+test("pubSubRegistry without initialValue has null lastValueEmitted", () => {
+  const registry = pubSubRegistry<string, string>();
+
+  const value = registry.allocate("foo");
+
+  expect(value.lastValueEmitted).toBe(null);
+});
+
+test("pubSubRegistry with initialValue sets lastValueEmitted and emits", () => {
+  const registry = pubSubRegistry<string, string>({
+    initialValue: (key) => `initial-${key}`,
+  });
+
+  const listener = vi.fn();
+  const _value = registry.allocate("foo");
+
+  // The initial value should have been emitted to any listeners
+  _value.subject.listen(listener, true);
+  expect(listener).toHaveBeenCalledWith("initial-foo");
+  expect(_value.lastValueEmitted).toEqual(["initial-foo"]);
+});
+
+test("pubSubRegistry initialValue is called with the key", () => {
+  const initialValue = vi.fn((key: string) => `value-${key}`);
+  const registry = pubSubRegistry<string, string>({
+    initialValue,
+  });
+
+  registry.allocate("test-key");
+
+  expect(initialValue).toHaveBeenCalledTimes(1);
+  expect(initialValue).toHaveBeenCalledWith("test-key");
+});
+
+test("pubSubRegistry multiple allocations return same instance", () => {
+  const registry = pubSubRegistry<string, string>();
+
+  const value1 = registry.allocate("foo");
+  const value2 = registry.allocate("foo");
+
+  expect(value1).toBe(value2);
+  expect(value1.subject).toBe(value2.subject);
+});
+
+test("pubSubRegistry different keys return different instances", () => {
+  const registry = pubSubRegistry<string, string>();
+
+  const value1 = registry.allocate("foo");
+  const value2 = registry.allocate("bar");
+
+  expect(value1).not.toBe(value2);
+  expect(value1.subject).not.toBe(value2.subject);
+});
+
+test("pubSubRegistry free decrements allocation count", () => {
+  const registry = pubSubRegistry<string, string>();
+
+  registry.allocate("foo");
+  registry.allocate("foo");
+
+  expect(registry.isAllocated("foo")).toBe(true);
+
+  registry.free("foo");
+  expect(registry.isAllocated("foo")).toBe(true); // Still allocated
+
+  registry.free("foo");
+  expect(registry.isAllocated("foo")).toBe(false); // Now freed
+});
+
+test("pubSubRegistry free non-existent key is safe", () => {
+  const registry = pubSubRegistry<string, string>();
+
+  expect(() => registry.free("nonexistent")).not.toThrow();
+  expect(registry.isAllocated("nonexistent")).toBe(false);
+});
+
+test("pubSubRegistry with shouldCleanup returning false keeps resource", () => {
+  const registry = pubSubRegistry<string, string>({
+    shouldCleanup: (_key, lastValue) => {
+      // Don't cleanup if last value was "persist"
+      return lastValue !== "persist";
+    },
+  });
+
+  const value = registry.allocate("foo");
+  value.lastValueEmitted = ["persist"];
+
+  registry.free("foo");
+
+  // Should still be allocated because shouldCleanup returned false
+  expect(registry.isAllocated("foo")).toBe(true);
+});
+
+test("pubSubRegistry with shouldCleanup returning true cleans up resource", () => {
+  const registry = pubSubRegistry<string, string>({
+    shouldCleanup: (_key, lastValue) => {
+      // Cleanup if last value was "cleanup"
+      return lastValue === "cleanup";
+    },
+  });
+
+  const value = registry.allocate("foo");
+  value.lastValueEmitted = ["cleanup"];
+
+  registry.free("foo");
+
+  // Should be cleaned up because shouldCleanup returned true
+  expect(registry.isAllocated("foo")).toBe(false);
+});
+
+test("pubSubRegistry shouldCleanup receives correct parameters", () => {
+  const shouldCleanup = vi.fn((_key: string, _lastValue: string) => true);
+  const registry = pubSubRegistry<string, string>({
+    shouldCleanup,
+  });
+
+  const value = registry.allocate("test-key");
+  value.lastValueEmitted = ["test-value"];
+
+  registry.free("test-key");
+
+  expect(shouldCleanup).toHaveBeenCalledTimes(1);
+  expect(shouldCleanup).toHaveBeenCalledWith("test-key", "test-value");
+});
+
+test("pubSubRegistry should always cleanup if there are no emitted values", () => {
+  const shouldCleanup = vi.fn((_key: string, lastValue: string) => {
+    expect(lastValue).toBe(null);
+    return true;
+  });
+  const registry = pubSubRegistry<string, string>({
+    shouldCleanup,
+  });
+
+  registry.allocate("test-key");
+  // Don't set lastValueEmitted, keep it as null
+
+  registry.free("test-key");
+
+  expect(shouldCleanup).not.toHaveBeenCalled();
+});
+
+test("pubSubRegistry default shouldCleanup behavior is true", () => {
+  const registry = pubSubRegistry<string, string>();
+
+  registry.allocate("foo");
+  registry.free("foo");
+
+  // Should be cleaned up by default
+  expect(registry.isAllocated("foo")).toBe(false);
+});
+
+test("pubSubRegistry initialValue emits to subject immediately", () => {
+  const registry = pubSubRegistry<string, string>({
+    initialValue: (key) => `init-${key}`,
+  });
+
+  const listener = vi.fn();
+  const value = registry.allocate("foo");
+
+  // Listen with immediate=true to catch the initial emission
+  value.subject.listen(listener, true);
+
+  expect(listener).toHaveBeenCalledTimes(1);
+  expect(listener).toHaveBeenCalledWith("init-foo");
+});
+
+test("pubSubRegistry works with different value types", () => {
+  const registry = pubSubRegistry<string, number>();
+
+  const value = registry.allocate("numbers");
+  expect(value.lastValueEmitted).toBe(null);
+
+  const listener = vi.fn();
+  value.subject.listen(listener);
+  value.subject.next(42);
+
+  expect(listener).toHaveBeenCalledWith(42);
+});
+
+// Tests for pubSub
+test("pubSub basic listen and next", () => {
+  const mq = pubSub(pubSubRegistry<string, string>());
+
+  const listener = vi.fn();
+  const unsubscribe = mq.listen("foo", listener);
+
+  expect(listener).not.toHaveBeenCalled();
+
+  mq.next("foo", "hello");
+
+  expect(listener).toHaveBeenCalledTimes(1);
+  expect(listener).toHaveBeenCalledWith("hello");
+
+  mq.next("foo", "world");
+
+  expect(listener).toHaveBeenCalledTimes(2);
+  expect(listener).toHaveBeenNthCalledWith(2, "world");
+
+  unsubscribe();
+});
+
+test("pubSub next to key with no listeners does nothing", () => {
+  const mq = pubSub(pubSubRegistry<string, string>());
+
+  const listener = vi.fn();
+  mq.listen("foo", listener);
+
+  // Publish to a different key with no listeners
+  mq.next("bar", "hello");
+
+  // Listener should not have been called
+  expect(listener).not.toHaveBeenCalled();
+});
+
+test("pubSub multiple listeners for same key", () => {
+  const mq = pubSub(pubSubRegistry<string, string>());
+
+  const listener1 = vi.fn();
+  const listener2 = vi.fn();
+  const listener3 = vi.fn();
+
+  const unsubscribe1 = mq.listen("foo", listener1);
+  const unsubscribe2 = mq.listen("foo", listener2);
+  const unsubscribe3 = mq.listen("foo", listener3);
+
+  mq.next("foo", "hello");
+
+  expect(listener1).toHaveBeenCalledTimes(1);
+  expect(listener1).toHaveBeenCalledWith("hello");
+  expect(listener2).toHaveBeenCalledTimes(1);
+  expect(listener2).toHaveBeenCalledWith("hello");
+  expect(listener3).toHaveBeenCalledTimes(1);
+  expect(listener3).toHaveBeenCalledWith("hello");
+
+  unsubscribe1();
+  unsubscribe2();
+  unsubscribe3();
+});
+
+test("pubSub multiple keys work independently", () => {
+  const mq = pubSub(pubSubRegistry<string, string>());
+
+  const listenerA = vi.fn();
+  const listenerB = vi.fn();
+
+  const unsubscribeA = mq.listen("topicA", listenerA);
+  const unsubscribeB = mq.listen("topicB", listenerB);
+
+  mq.next("topicA", "messageA");
+  mq.next("topicB", "messageB");
+
+  expect(listenerA).toHaveBeenCalledTimes(1);
+  expect(listenerA).toHaveBeenCalledWith("messageA");
+  expect(listenerB).not.toHaveBeenCalledWith("messageA");
+  expect(listenerB).toHaveBeenCalledTimes(1);
+  expect(listenerB).toHaveBeenCalledWith("messageB");
+  expect(listenerA).not.toHaveBeenCalledWith("messageB");
+
+  unsubscribeA();
+  unsubscribeB();
+});
+
+test("pubSub unsubscribe removes listener", () => {
+  const mq = pubSub(pubSubRegistry<string, string>());
+
+  const listener = vi.fn();
+  const unsubscribe = mq.listen("foo", listener);
+
+  mq.next("foo", "hello");
+  expect(listener).toHaveBeenCalledTimes(1);
+
+  unsubscribe();
+
+  mq.next("foo", "world");
+  // Listener should not receive the second message
+  expect(listener).toHaveBeenCalledTimes(1);
+  expect(listener).not.toHaveBeenCalledWith("world");
+});
+
+test("pubSub multiple unsubscribes for same key", () => {
+  const mq = pubSub(pubSubRegistry<string, string>());
+
+  const listener1 = vi.fn();
+  const listener2 = vi.fn();
+  const listener3 = vi.fn();
+
+  const unsubscribe1 = mq.listen("foo", listener1);
+  const unsubscribe2 = mq.listen("foo", listener2);
+  const unsubscribe3 = mq.listen("foo", listener3);
+
+  mq.next("foo", "first");
+  expect(listener1).toHaveBeenCalledTimes(1);
+  expect(listener2).toHaveBeenCalledTimes(1);
+  expect(listener3).toHaveBeenCalledTimes(1);
+
+  unsubscribe1();
+
+  mq.next("foo", "second");
+  expect(listener1).toHaveBeenCalledTimes(1); // No new calls
+  expect(listener2).toHaveBeenCalledTimes(2);
+  expect(listener3).toHaveBeenCalledTimes(2);
+
+  unsubscribe2();
+
+  mq.next("foo", "third");
+  expect(listener1).toHaveBeenCalledTimes(1);
+  expect(listener2).toHaveBeenCalledTimes(2);
+  expect(listener3).toHaveBeenCalledTimes(3);
+
+  unsubscribe3();
+});
+
+test("pubSub with initial value no immediate", () => {
+  const mq = pubSub(
+    pubSubRegistry<string, string>({
+      initialValue: (key) => `initial-${key}`,
+    })
+  );
+
+  const listener = vi.fn();
+  const unsubscribe = mq.listen("foo", listener);
+
+  // Listener should not be called immediately (subject doesn't emit initial value by default)
+  expect(listener).not.toHaveBeenCalled();
+
+  mq.next("foo", "hello");
+  expect(listener).toHaveBeenCalledTimes(1);
+  expect(listener).toHaveBeenCalledWith("hello");
+
+  unsubscribe();
+});
+
+test("pubSub with initial value and immediate", () => {
+  const mq = pubSub(
+    pubSubRegistry<string, string>({
+      initialValue: (key) => `initial-${key}`,
+    })
+  );
+
+  const listener = vi.fn();
+
+  const unsubscribe = mq.listen("foo", listener, true);
+
+  expect(listener).toHaveBeenCalled();
+  expect(listener).toHaveBeenCalledTimes(1);
+  expect(listener).toHaveBeenCalledWith("initial-foo");
+
+  mq.next("foo", "hello");
+
+  // Listener should not be called immediately (subject doesn't emit initial value by default)
+  expect(listener).toHaveBeenCalled();
+  expect(listener).toHaveBeenCalledTimes(2);
+  expect(listener).toHaveBeenCalledWith("hello");
+
+  unsubscribe();
+});
+
+test("pubSub next only emits if key is allocated", () => {
+  const mq = pubSub(pubSubRegistry<string, string>());
+
+  // Try to publish to a key with no listeners
+  mq.next("unsubscribed", "message");
+
+  // Should not throw, but also shouldn't do anything
+  const listener = vi.fn();
+  mq.listen("unsubscribed", listener);
+
+  // Now publish again - should work
+  mq.next("unsubscribed", "message2");
+  expect(listener).toHaveBeenCalledTimes(1);
+  expect(listener).toHaveBeenCalledWith("message2");
+});
+
+test("pubSub works with different value types", () => {
+  const mq = pubSub(pubSubRegistry<string, number>());
+
+  const listener = vi.fn();
+  const unsubscribe = mq.listen("numbers", listener);
+
+  mq.next("numbers", 42);
+  expect(listener).toHaveBeenCalledWith(42);
+
+  mq.next("numbers", 100);
+  expect(listener).toHaveBeenCalledWith(100);
+
+  unsubscribe();
+});
+
+test("pubSub works with object values", () => {
+  const mq = pubSub(pubSubRegistry<string, { id: number; name: string }>());
+
+  const listener = vi.fn();
+  const unsubscribe = mq.listen("objects", listener);
+
+  const value1 = { id: 1, name: "test" };
+  mq.next("objects", value1);
+  expect(listener).toHaveBeenCalledWith(value1);
+
+  const value2 = { id: 2, name: "test2" };
+  mq.next("objects", value2);
+  expect(listener).toHaveBeenCalledWith(value2);
+
+  unsubscribe();
+});
+
+test("pubSub with numeric keys", () => {
+  const mq = pubSub(pubSubRegistry<number, string>());
+
+  const listener1 = vi.fn();
+  const listener2 = vi.fn();
+
+  const unsubscribe1 = mq.listen(1, listener1);
+  const unsubscribe2 = mq.listen(2, listener2);
+
+  mq.next(1, "message1");
+  mq.next(2, "message2");
+
+  expect(listener1).toHaveBeenCalledWith("message1");
+  expect(listener2).toHaveBeenCalledWith("message2");
+
+  unsubscribe1();
+  unsubscribe2();
+});
+
+test("pubSub cleanup behavior when all listeners unsubscribe", () => {
+  const mq = pubSub(pubSubRegistry<string, string>());
+
+  const listener1 = vi.fn();
+  const listener2 = vi.fn();
+
+  const unsubscribe1 = mq.listen("foo", listener1);
+  const unsubscribe2 = mq.listen("foo", listener2);
+
+  mq.next("foo", "hello");
+  expect(listener1).toHaveBeenCalledTimes(1);
+  expect(listener2).toHaveBeenCalledTimes(1);
+
+  unsubscribe1();
+  unsubscribe2();
+
+  // After all listeners unsubscribe, next should not emit
+  mq.next("foo", "world");
+  expect(listener1).toHaveBeenCalledTimes(1);
+  expect(listener2).toHaveBeenCalledTimes(1);
+});
+
+test("pubSub with shouldCleanup option prevents cleanup", () => {
+  const registry = pubSubRegistry<string, string>({
+    shouldCleanup: (_key, lastValue) => {
+      // Don't cleanup if last value was "keep"
+      return lastValue !== "keep";
+    },
+  });
+  const mq = pubSub(registry);
+
+  const listener = vi.fn();
+  const unsubscribe = mq.listen("foo", listener);
+
+  mq.next("foo", "keep");
+  expect(listener).toHaveBeenCalledWith("keep");
+
+  unsubscribe();
+
+  // Since last value was "keep", shouldCleanup returns false, so resource should still be allocated
+  expect(registry.isAllocated("foo")).toBe(true);
+});
+
+test("pubSub with shouldCleanup option allows cleanup", () => {
+  const registry = pubSubRegistry<string, string>({
+    shouldCleanup: (_key, lastValue) => {
+      // Cleanup if last value was "cleanup"
+      return lastValue === "cleanup";
+    },
+  });
+  const mq = pubSub(registry);
+
+  const listener = vi.fn();
+  const unsubscribe = mq.listen("foo", listener);
+
+  mq.next("foo", "cleanup");
+  expect(listener).toHaveBeenCalledWith("cleanup");
+
+  unsubscribe();
+
+  // Since last value was "cleanup", shouldCleanup returns true, so resource
+  // should be cleaned up
+  expect(registry.isAllocated("foo")).toBe(false);
+});
+
+test("pubSub real-world no added emit", () => {
+  type Status = { type: "idle" } | { type: "running" } | { type: "done" };
+  const ps = pubSub(
+    pubSubRegistry<string, Status>({
+      initialValue: () => ({ type: "idle" }),
+      shouldCleanup: (_, lastEmittedValue) =>
+        lastEmittedValue.type !== "running",
+    })
+  );
+
+  const listener = vi.fn();
+
+  const unsubscribe = ps.listen("cool", listener, true);
+
+  expect(listener).toHaveBeenCalled();
+  expect(listener).toHaveBeenCalledTimes(1);
+  expect(listener).toHaveBeenCalledWith(
+    expect.objectContaining({
+      type: "idle",
+    })
+  );
+
+  unsubscribe();
+});
+
+test("pubSub real-world no added emit", () => {
+  type Status = { type: "idle" } | { type: "running" } | { type: "done" };
+  const ps = pubSub(
+    pubSubRegistry<string, Status>({
+      initialValue: () => ({ type: "idle" }),
+      shouldCleanup: (_, lastEmittedValue) =>
+        lastEmittedValue.type !== "running",
+    })
+  );
+
+  const listener = vi.fn();
+
+  const unsubscribe = ps.listen("cool", listener, true);
+
+  expect(listener).toHaveBeenCalled();
+  expect(listener).toHaveBeenCalledTimes(1);
+  expect(listener).toHaveBeenCalledWith(
+    expect.objectContaining({
+      type: "idle",
+    })
+  );
+
+  unsubscribe();
+});
+
+test("pubSub real-world, with added emit, subscribed after", () => {
+  type Status = { type: "idle" } | { type: "running" } | { type: "done" };
+
+  const shouldCleanupListener = vi.fn();
+
+  const ps = pubSub(
+    pubSubRegistry<string, Status>({
+      initialValue: () => ({ type: "idle" }),
+      shouldCleanup: (_, lastEmittedValue) => {
+        const shouldClean = lastEmittedValue.type !== "running";
+        expect(lastEmittedValue.type).toBe("running");
+        expect(shouldClean).toBe(false);
+        shouldCleanupListener(shouldClean);
+        return shouldClean;
+      },
+    })
+  );
+
+  ps.next("cool", { type: "running" });
+
+  expect(shouldCleanupListener).toHaveBeenCalled();
+  expect(shouldCleanupListener).toHaveBeenCalledTimes(1);
+  expect(shouldCleanupListener).toHaveBeenCalledWith(false);
+
+  const listener = vi.fn();
+
+  const unsubscribe = ps.listen("cool", listener, true);
+
+  expect(listener).toHaveBeenCalled();
+  expect(listener).toHaveBeenCalledTimes(1);
+  expect(listener).toHaveBeenCalledWith(
+    expect.objectContaining({
+      type: "running",
+    })
+  );
+
+  unsubscribe();
+});
+
+test("pubSub real-world, with two added emits, subscribed after both", () => {
+  type Status = { type: "idle" } | { type: "running" } | { type: "done" };
+
+  const shouldCleanupListener = vi.fn();
+
+  const ps = pubSub(
+    pubSubRegistry<string, Status>({
+      initialValue: () => ({ type: "idle" }),
+      shouldCleanup: (_, lastEmittedValue) => {
+        const shouldClean = lastEmittedValue.type !== "running";
+        shouldCleanupListener(shouldClean);
+        return shouldClean;
+      },
+    })
+  );
+
+  ps.next("cool", { type: "running" });
+
+  expect(shouldCleanupListener).toHaveBeenCalled();
+  expect(shouldCleanupListener).toHaveBeenCalledTimes(1);
+  expect(shouldCleanupListener).toHaveBeenCalledWith(false);
+
+  ps.next("cool", { type: "done" });
+
+  expect(shouldCleanupListener).toHaveBeenCalledTimes(2);
+  expect(shouldCleanupListener).toHaveBeenCalledWith(true);
+
+  const listener = vi.fn();
+
+  const unsubscribe = ps.listen("cool", listener, true);
+
+  expect(listener).toHaveBeenCalled();
+  expect(listener).toHaveBeenCalledTimes(1);
+  expect(listener).toHaveBeenCalledWith(
+    expect.objectContaining({
+      type: "idle",
+    })
+  );
+
+  unsubscribe();
+});
+
+test("pubSub real-world, with two added emits, one subscribed after running, the other after done", () => {
+  type Status = { type: "idle" } | { type: "running" } | { type: "done" };
+
+  const shouldCleanupListener = vi.fn();
+
+  const ps = pubSub(
+    pubSubRegistry<string, Status>({
+      initialValue: () => ({ type: "idle" }),
+      shouldCleanup: (_, lastEmittedValue) => {
+        const shouldClean = lastEmittedValue.type !== "running";
+        shouldCleanupListener(shouldClean);
+        return shouldClean;
+      },
+    })
+  );
+
+  ps.next("cool", { type: "running" });
+
+  expect(shouldCleanupListener).toHaveBeenCalled();
+  expect(shouldCleanupListener).toHaveBeenCalledTimes(1);
+  expect(shouldCleanupListener).toHaveBeenCalledWith(false);
+
+  const listener1 = vi.fn();
+
+  const unsubscribe1 = ps.listen("cool", listener1, true);
+
+  expect(listener1).toHaveBeenCalled();
+  expect(listener1).toHaveBeenCalledTimes(1);
+  expect(listener1).toHaveBeenCalledWith(
+    expect.objectContaining({
+      type: "running",
+    })
+  );
+
+  ps.next("cool", { type: "done" });
+
+  expect(shouldCleanupListener).toHaveBeenCalledTimes(1);
+  expect(shouldCleanupListener).toHaveBeenCalledWith(false);
+
+  const listener2 = vi.fn();
+
+  const unsubscribe2 = ps.listen("cool", listener2, true);
+
+  expect(listener2).toHaveBeenCalled();
+  expect(listener2).toHaveBeenCalledTimes(1);
+  expect(listener2).toHaveBeenCalledWith(
+    expect.objectContaining({
+      type: "done",
+    })
+  );
+
+  unsubscribe1();
+  unsubscribe2();
+
+  expect(shouldCleanupListener).toHaveBeenCalledTimes(2);
+  expect(shouldCleanupListener).toHaveBeenCalledWith(true);
+});
+
+test("pubSub real-world, with two added emits, one subscribed after running, the other after done, with first one unsubscribing", () => {
+  type Status = { type: "idle" } | { type: "running" } | { type: "done" };
+
+  const shouldCleanupListener = vi.fn();
+
+  const ps = pubSub(
+    pubSubRegistry<string, Status>({
+      initialValue: () => ({ type: "idle" }),
+      shouldCleanup: (_, lastEmittedValue) => {
+        const shouldClean = lastEmittedValue.type !== "running";
+        shouldCleanupListener(shouldClean);
+        return shouldClean;
+      },
+    })
+  );
+
+  ps.next("cool", { type: "running" });
+
+  expect(shouldCleanupListener).toHaveBeenCalled();
+  expect(shouldCleanupListener).toHaveBeenCalledTimes(1);
+  expect(shouldCleanupListener).toHaveBeenCalledWith(false);
+
+  const listener1 = vi.fn();
+
+  const unsubscribe1 = ps.listen("cool", listener1, true);
+
+  expect(listener1).toHaveBeenCalled();
+  expect(listener1).toHaveBeenCalledTimes(1);
+  expect(listener1).toHaveBeenCalledWith(
+    expect.objectContaining({
+      type: "running",
+    })
+  );
+
+  unsubscribe1();
+
+  expect(shouldCleanupListener).toHaveBeenCalled();
+  expect(shouldCleanupListener).toHaveBeenCalledTimes(2);
+  expect(shouldCleanupListener).toHaveBeenCalledWith(false);
+
+  ps.next("cool", { type: "done" });
+
+  expect(shouldCleanupListener).toHaveBeenCalledTimes(3);
+  expect(shouldCleanupListener).toHaveBeenCalledWith(true);
+
+  const listener2 = vi.fn();
+
+  const unsubscribe2 = ps.listen("cool", listener2, true);
+
+  expect(listener2).toHaveBeenCalled();
+  expect(listener2).toHaveBeenCalledTimes(1);
+  expect(listener2).toHaveBeenCalledWith(
+    expect.objectContaining({
+      type: "idle",
+    })
+  );
+
+  unsubscribe2();
+});

--- a/src/utils/pub-sub/pub-sub.ts
+++ b/src/utils/pub-sub/pub-sub.ts
@@ -1,0 +1,134 @@
+import { resourceRegistry } from "../resource-registry/resource-registry";
+import { subject } from "../subject/subject";
+
+/**
+ * A type that pairs a subject with its last emitted value.
+ *
+ * This type is used to enable pub-sub functionality while also maintaining
+ * the last emitted value, allowing the pub-sub system to double as a key-value
+ * store where the "value" is the last event emitted for a given topic.
+ *
+ * @template Value The type of value that the subject emits and stores.
+ */
+type SubjectAndLastValue<Value> = {
+  /**
+   * The last value that was emitted by the subject,
+   * stored as a single-element tuple `[Value]`, or `null` if no value has been
+   * emitted yet.
+   */
+  lastValueEmitted: [Value] | null;
+
+  /**
+   * The subject instance that manages subscriptions and
+   * emits values to listeners.
+   */
+  subject: ReturnType<typeof subject<Value>>;
+};
+
+/**
+ * This function is a helper for initializing a "resource registry" purely for
+ * usecases that involve pub-sub (especially within a same-process/in-memory
+ * pub-sub manager).
+ *
+ * The first advantage is that the return value matches the parameter type of
+ * what `pubSub` expects.
+ *
+ * The other advantage is that unlike `resourceRegistry`'s initialization logic,
+ * this function has it so that when a subject is initialized, a newly-created
+ * subject will always have an initial value emitted, if an `initialValue`
+ * function was supplied in the option.
+ *
+ * This aspect is especially useful if we are to double pub-sub as a key-value
+ * store, that associates "last event" as a "value" in the key-value pair.
+ * @param options An object of optional methods, those being `initialValue` and
+ *   `shouldCleanup`. Initial value decides the initial value to emit when a
+ *   new subject has been initialized. A subject is initialized either when the
+ *   resource registry has initialized, or when a subject has been cleaned out.
+ * @returns A "resource registry"
+ * @see resourceRegistry
+ * @see pubSub
+ */
+export function pubSubRegistry<Key, Value>({
+  initialValue,
+  shouldCleanup,
+}: {
+  initialValue?: (key: Key) => Value;
+  shouldCleanup?: (key: Key, event: Value) => boolean;
+} = {}) {
+  return resourceRegistry<Key, SubjectAndLastValue<Value>>(
+    (key) => {
+      const sub = subject<Value>();
+      const init = initialValue
+        ? ([initialValue(key)] satisfies [Value])
+        : null;
+      if (init !== null) {
+        sub.next(init[0]);
+      }
+      return {
+        lastValueEmitted: init,
+        subject: sub,
+      };
+    },
+
+    (key, event) => {
+      if (event.lastValueEmitted === null) return true;
+      return shouldCleanup?.(key, event.lastValueEmitted[0]) ?? true;
+    }
+  );
+}
+
+/**
+ * Returns a pub/sub registry that is intended to subscribe to a topic, and
+ * publish to it.
+ *
+ * Usage:
+ *
+ *     const mq = pubSub<string, string>(pubSubRegistry());
+ *
+ *     mq.listen('foo', (value) => console.log(`${value}`));
+ *
+ *     mq.next('foo', 'hello'); // Should have emitted "hello"
+ *
+ *     mq.next('bar', 'hello'); // Nothing, because no subscriber to `bar`.
+ *
+ *     mq.next('foo', world'); // Should have emitted "world"
+ * @param options allows one to provide an optional "initial value" provider,
+ *   and a predicate function to determine whether to clear out the subject
+ *   when all listeners have unsubscribed.
+ * @returns An object that contains a `listen` and a `next` method, where
+ *   `listen` allows the client code to listen to events to a specific topic
+ *   (keyed by `key`), and `next` allows the client code to emit an event to all
+ *   listeners.
+ */
+export function pubSub<Key, Value>(
+  registry: ReturnType<typeof resourceRegistry<Key, SubjectAndLastValue<Value>>>
+) {
+  const listen = (
+    key: Key,
+    listener: (value: Value) => void,
+    immediate?: boolean
+  ): (() => void) => {
+    const subjectAndLastValue = registry.allocate(key);
+    const unsubscribe = subjectAndLastValue.subject.listen(listener, immediate);
+
+    return () => {
+      registry.free(key);
+      unsubscribe();
+    };
+  };
+  const next = (key: Key, value: Value) => {
+    const subjectAndLastValue = registry.allocate(key);
+    subjectAndLastValue.lastValueEmitted = [value];
+    registry.free(key);
+    subjectAndLastValue.subject.next(value);
+  };
+
+  return {
+    listen,
+    next,
+    subject: (key: Key): ReturnType<typeof subject<Value>> => ({
+      listen: (...args) => listen(key, ...args),
+      next: (...args) => next(key, ...args),
+    }),
+  };
+}

--- a/src/utils/resource-registry/resource-registry.test.ts
+++ b/src/utils/resource-registry/resource-registry.test.ts
@@ -1,0 +1,128 @@
+import { expect, test, vi } from "vitest";
+import { resourceRegistry } from "./resource-registry";
+
+test("resourceRegistry basic allocation and freeing", () => {
+  const registry = resourceRegistry((key: number) => `value-${key}`);
+
+  expect(registry.isAllocated(10)).toBe(false);
+
+  const value1 = registry.allocate(10);
+  expect(value1).toBe("value-10");
+  expect(registry.isAllocated(10)).toBe(true);
+
+  const value2 = registry.allocate(10);
+  expect(value2).toBe("value-10");
+  expect(value1).toBe(value2); // Should return the same instance
+  expect(registry.isAllocated(10)).toBe(true);
+
+  registry.free(10);
+  // After one free, should still be allocated (count was 2, now 1)
+  expect(registry.isAllocated(10)).toBe(true);
+
+  registry.free(10);
+  // After second free, should be cleaned up (count was 1, now 0)
+  expect(registry.isAllocated(10)).toBe(false);
+});
+
+test("resourceRegistry multiple keys", () => {
+  const registry = resourceRegistry((key: string) => ({ id: key }));
+
+  const valueA = registry.allocate("a");
+  const valueB = registry.allocate("b");
+
+  expect(valueA.id).toBe("a");
+  expect(valueB.id).toBe("b");
+  expect(registry.isAllocated("a")).toBe(true);
+  expect(registry.isAllocated("b")).toBe(true);
+
+  registry.free("a");
+  expect(registry.isAllocated("a")).toBe(false);
+  expect(registry.isAllocated("b")).toBe(true);
+
+  registry.free("b");
+  expect(registry.isAllocated("b")).toBe(false);
+});
+
+test("resourceRegistry free non-existent key is safe", () => {
+  const registry = resourceRegistry((key: number) => key * 2);
+
+  expect(() => registry.free(999)).not.toThrow();
+  expect(registry.isAllocated(999)).toBe(false);
+});
+
+test("resourceRegistry with shouldCleanup returning false", () => {
+  const registry = resourceRegistry(
+    (key: number) => ({ key, data: "test" }),
+    (_, value) => value.key !== 5 // Don't cleanup key 5
+  );
+
+  registry.allocate(5);
+  expect(registry.isAllocated(5)).toBe(true);
+
+  registry.free(5);
+  // Should still be allocated because shouldCleanup returned false
+  expect(registry.isAllocated(5)).toBe(true);
+
+  registry.allocate(10);
+  registry.free(10);
+  // Should be cleaned up because shouldCleanup returns true (default)
+  expect(registry.isAllocated(10)).toBe(false);
+});
+
+test("resourceRegistry with shouldCleanup conditional cleanup", () => {
+  const registry = resourceRegistry(
+    (key: number) => ({ key }),
+    (_, value) => value.key <= 100 // Only cleanup keys <= 100
+  );
+
+  registry.allocate(50);
+  registry.free(50);
+  // Should be cleaned up because shouldCleanup returns true for key 50
+  expect(registry.isAllocated(50)).toBe(false);
+
+  registry.allocate(150);
+  registry.free(150);
+  // Should still be allocated because shouldCleanup returned false for key 150
+  expect(registry.isAllocated(150)).toBe(true);
+});
+
+test("resourceRegistry initialize function is called only once per key", () => {
+  const initialize = vi.fn((key: number) => `value-${key}`);
+  const registry = resourceRegistry(initialize);
+
+  registry.allocate(10);
+  expect(initialize).toHaveBeenCalledTimes(1);
+  expect(initialize).toHaveBeenCalledWith(10);
+
+  registry.allocate(10);
+  // Should not call initialize again for the same key
+  expect(initialize).toHaveBeenCalledTimes(1);
+
+  registry.allocate(20);
+  expect(initialize).toHaveBeenCalledTimes(2);
+  expect(initialize).toHaveBeenCalledWith(20);
+});
+
+test("resourceRegistry free multiple times on same key", () => {
+  const registry = resourceRegistry((key: number) => key);
+
+  registry.allocate(10);
+  registry.free(10);
+  expect(registry.isAllocated(10)).toBe(false);
+
+  // Freeing again should be safe
+  registry.free(10);
+  expect(registry.isAllocated(10)).toBe(false);
+});
+
+test("resourceRegistry allocate should return the same value for the same key", () => {
+  const registry = resourceRegistry((key: number) => ({ id: key }));
+
+  const valueA = registry.allocate(10);
+  const valueB = registry.allocate(10);
+  const valueC = registry.allocate(20);
+
+  expect(valueA).toBe(valueB);
+  expect(valueA).not.toBe(valueC);
+  expect(valueB).not.toBe(valueC);
+});

--- a/src/utils/resource-registry/resource-registry.ts
+++ b/src/utils/resource-registry/resource-registry.ts
@@ -1,0 +1,73 @@
+/**
+ * Initializes a resource registry, that will allow consumers to share and
+ * access a single resource keyed by a key.
+ *
+ * Usage:
+ *
+ *     const registry = resourceRegistry((key) => key);
+ *
+ *     console.log(registry.isAllocated(10)); // false
+ *
+ *     registry.allocate(10);
+ *
+ *     console.log(registry.isAllocated(10)); // true;
+ *
+ *     registry.allocate(10);
+ *
+ *     registry.free(10);
+ *
+ *     console.log(registry.isAllocated(10)); // true
+ *
+ *     registry.free(10);
+ *
+ *     console.log(registry.isAllocated(10)); // false
+ * @param initialize a function to initialize the first value, if one doesn't
+ *   yet exist.
+ * @param shouldCleanup An optional predicate function to determine whether to
+ *   clear the resource.
+ * @returns An object with two key methods: `allocate` and `free`, where
+ *   `allocate` either initializes the resource, or gives an existing one to the
+ *   consumer, and `free` notiifies the registry to indicate there is one less
+ *   consumer of a resource.
+ */
+export function resourceRegistry<Key, Value>(
+  initialize: (key: Key) => Value,
+  shouldCleanup?: (key: Key, value: Value) => boolean
+) {
+  const allocations = new Map<
+    Key,
+    {
+      allocationCount: number;
+      value: Value;
+    }
+  >();
+
+  return {
+    allocate: (key: Key): Value => {
+      let value = allocations.get(key);
+      if (!value) {
+        value = {
+          allocationCount: 1,
+          value: initialize(key),
+        };
+        allocations.set(key, value);
+      } else {
+        value.allocationCount += 1;
+      }
+      return value.value;
+    },
+    free: (key: Key): void => {
+      const value = allocations.get(key);
+      if (!value) return;
+      value.allocationCount =
+        value.allocationCount === 0 ? 0 : value.allocationCount - 1;
+      if (
+        value.allocationCount === 0 &&
+        (shouldCleanup?.(key, value.value) ?? true)
+      ) {
+        allocations.delete(key);
+      }
+    },
+    isAllocated: (key: Key): boolean => allocations.has(key),
+  };
+}

--- a/src/utils/subject/subject.test.ts
+++ b/src/utils/subject/subject.test.ts
@@ -1,0 +1,44 @@
+import { expect, test, vi } from "vitest";
+import { firstFromSubjectSync, subject } from "./subject";
+
+test("subject listen, next, and unsubscribe", () => {
+  const sub = subject<string>();
+
+  const listener = vi.fn();
+  const unsubscribe = sub.listen(listener);
+
+  expect(listener).not.toHaveBeenCalled();
+
+  sub.next("hello");
+
+  expect(listener).toHaveBeenNthCalledWith(1, "hello");
+
+  sub.next("world");
+
+  expect(listener).toHaveBeenNthCalledWith(2, "world");
+  expect(listener).toHaveBeenCalledTimes(2);
+
+  unsubscribe();
+
+  sub.next("nothing");
+  // Assert that listener has only been called for the first two emissions
+  expect(listener).toHaveBeenCalledTimes(2);
+  expect(listener).toHaveBeenNthCalledWith(1, "hello");
+  expect(listener).toHaveBeenNthCalledWith(2, "world");
+  expect(listener).not.toHaveBeenCalledWith("nothing");
+});
+
+test("firstFromSubjectSync returns last emitted value synchronously", () => {
+  const sub = subject<string>();
+
+  // No value has been emitted yet, so there should be no synchronous value.
+  expect(firstFromSubjectSync(sub)).toBeNull();
+
+  // Emit a value and expect it to be captured.
+  sub.next("first");
+  expect(firstFromSubjectSync(sub)).toEqual(["first"]);
+
+  // Emit another value and ensure the latest one is what we get.
+  sub.next("second");
+  expect(firstFromSubjectSync(sub)).toEqual(["second"]);
+});

--- a/src/utils/subject/subject.ts
+++ b/src/utils/subject/subject.ts
@@ -1,0 +1,35 @@
+/**
+ * Returns an event emitter.
+ * @returns An object containing a function to add an event listener, and one
+ *   to push events to add to the listener.
+ */
+export function subject<T>() {
+  const listeners = new Set<(v: T) => void>();
+  let last: [T] | null = null;
+  return {
+    listen: (listener: (v: T) => void, immediate = false) => {
+      if (last !== null && immediate) listener(last[0]);
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    next: (v: T) => {
+      last = [v];
+      for (const listener of listeners) {
+        listener(v);
+      }
+    },
+  };
+}
+
+export const firstFromSubjectSync = <T>(
+  sub: ReturnType<typeof subject<T>>
+): [T] | null => {
+  let value: [T] | null = null;
+  const unsubscibe = sub.listen((v) => {
+    value = [v];
+  }, true);
+  unsubscibe();
+  return value;
+};

--- a/src/utils/task-runner-repository/task-runner-repository.test.ts
+++ b/src/utils/task-runner-repository/task-runner-repository.test.ts
@@ -1,0 +1,419 @@
+import { describe, it, expect, vi } from "vitest";
+import { Observable } from "rxjs";
+import { createTaskRunnerRepository } from "./task-runner-repository";
+
+type RunningState = { progress: number };
+
+describe("jobRunner", () => {
+  it("should start in idle state with null stopped data", () => {
+    const runner = createTaskRunnerRepository<string, RunningState>();
+
+    const state = runner.getTaskRunnerStateNode("job-1");
+
+    if (state.type !== "idle") {
+      throw new Error("Expected initial state to be idle");
+    }
+
+    expect(state.error).toBeNull();
+    expect(typeof state.run).toBe("function");
+  });
+
+  it("should transition to running when start is called", () => {
+    const runner = createTaskRunnerRepository<string, RunningState>();
+
+    const initialNode = runner.getTaskRunnerStateNode("job-1");
+
+    if (initialNode.type !== "idle") {
+      throw new Error("Expected initial state to be idle");
+    }
+
+    const jobFn = vi.fn(() => new Observable<RunningState>(() => {}));
+    initialNode.run(jobFn);
+
+    const runningState = runner.getTaskRunnerStateNode("job-1");
+
+    if (runningState.type !== "running") {
+      throw new Error("Expected state to be running");
+    }
+
+    expect(runningState.data).toBeNull();
+    expect(jobFn).toHaveBeenCalledTimes(1);
+    expect(typeof runningState.stop).toBe("function");
+  });
+
+  it("should emit progress updates while running", () => {
+    const repository = createTaskRunnerRepository<string, RunningState>();
+
+    const initialState = repository.getTaskRunnerStateNode("job-1");
+
+    if (initialState.type !== "idle") {
+      throw new Error("Expected initial state to be idle");
+    }
+
+    initialState.run(() => {
+      return new Observable<RunningState>((subscriber) => {
+        subscriber.next({ progress: 10 });
+        subscriber.next({ progress: 20 });
+      });
+    });
+
+    const runningState = repository.getTaskRunnerStateNode("job-1");
+
+    expect(runningState.type).toBe("running");
+    // Last progress update should be stored as [RunningState]
+    if (runningState.type === "running") {
+      expect(runningState.data).toEqual([{ progress: 20 }]);
+    }
+  });
+
+  it("should transition back to idle when stop is called from running state", () => {
+    const runner = createTaskRunnerRepository<string, RunningState>();
+
+    const key = "job-1";
+
+    const initialState = runner.getTaskRunnerStateNode(key);
+
+    runner.listen(key, () => {});
+
+    if (initialState.type !== "idle") {
+      throw new Error("Expected initial state to be idle");
+    }
+
+    initialState.run(() => {
+      return new Observable<RunningState>((subscriber) => {
+        // Observable completes immediately, which triggers stop
+        subscriber.complete();
+      });
+    });
+
+    const idleState = runner.getTaskRunnerStateNode(key);
+
+    expect(idleState.type).toBe("idle");
+    if (idleState.type === "idle") {
+      expect(idleState.error).toBe(null);
+    }
+  });
+
+  it("should allow external stop on running state", () => {
+    const runner = createTaskRunnerRepository<string, RunningState>();
+
+    const key = "job-1";
+
+    runner.listen(key, () => {});
+
+    const initialState = runner.getTaskRunnerStateNode(key);
+
+    if (initialState.type !== "idle") {
+      throw new Error("Expected initial state to be idle");
+    }
+
+    initialState.run(() => {
+      // Return an observable that never completes, keeping job running
+      return new Observable<RunningState>(() => {
+        // No-op: observable never completes or emits
+      });
+    });
+
+    const runningState = runner.getTaskRunnerStateNode(key);
+
+    if (runningState.type !== "running") {
+      throw new Error("Expected state to be running");
+    }
+
+    runningState.stop([{ reason: "stopped externally" }]);
+
+    const idleState = runner.getTaskRunnerStateNode(key);
+
+    expect(idleState.type).toBe("idle");
+    if (idleState.type === "idle") {
+      expect(idleState.error).toEqual([{ reason: "stopped externally" }]);
+    }
+  });
+
+  it("should pass an AbortSignal to the job and abort when stopped", () => {
+    const runner = createTaskRunnerRepository<string, RunningState>();
+
+    const initialState = runner.getTaskRunnerStateNode("job-1");
+
+    if (initialState.type !== "idle") {
+      throw new Error("Expected initial state to be idle");
+    }
+
+    const abortHandler = vi.fn();
+
+    initialState.run(({ abortSignal }) => {
+      abortSignal.addEventListener("abort", abortHandler);
+      // Return an observable that never completes, keeping job running
+      return new Observable<RunningState>(() => {
+        // No-op: observable never completes or emits
+      });
+    });
+
+    const runningState = runner.getTaskRunnerStateNode("job-1");
+
+    if (runningState.type !== "running") {
+      throw new Error("Expected state to be running");
+    }
+
+    runningState.stop();
+
+    expect(abortHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it("should allow subscribing after task has started and receive current state and future updates, in immediate mode", () => {
+    const runner = createTaskRunnerRepository<string, RunningState>();
+
+    const key = "job-1";
+    const initialState = runner.getTaskRunnerStateNode(key);
+
+    if (initialState.type !== "idle") {
+      throw new Error("Expected initial state to be idle");
+    }
+
+    // Start the task first
+    const progressValues: RunningState[] = [];
+    const emitLaterRef: { current: (() => void) | null } = { current: null };
+    initialState.run(() => {
+      return new Observable<RunningState>((subscriber) => {
+        // Emit initial progress
+        subscriber.next({ progress: 10 });
+        subscriber.next({ progress: 20 });
+
+        // Store function to emit more progress after subscription
+        emitLaterRef.current = () => {
+          subscriber.next({ progress: 30 });
+          subscriber.next({ progress: 40 });
+        };
+        // Don't complete - keep observable alive
+      });
+    });
+
+    // Verify task is running
+    const runningState = runner.getTaskRunnerStateNode(key);
+    expect(runningState.type).toBe("running");
+    if (runningState.type === "running") {
+      expect(runningState.data![0].progress).toBe(20);
+    }
+
+    // Now subscribe AFTER the task has started
+    const listener = vi.fn(
+      (state: {
+        type: "idle" | "running";
+        data?: [RunningState] | null;
+        error?: [unknown] | null;
+      }) => {
+        if (state.type === "running" && state.data) {
+          progressValues.push(state.data[0]);
+        }
+      }
+    );
+
+    const unsubscribe = runner.listen(key, listener, true);
+
+    // With immediate: true, should receive current state immediately
+    expect(listener).toHaveBeenCalled();
+    expect(progressValues.length).toBeGreaterThan(0);
+    // Should have received the last emitted progress (20) immediately
+    expect(progressValues).toContainEqual({ progress: 20 });
+
+    // Now emit more progress after subscription
+    if (emitLaterRef.current) {
+      emitLaterRef.current();
+    }
+
+    // Wait a bit for updates to propagate
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        // Should have received future updates (30, 40)
+        expect(progressValues).toContainEqual({ progress: 30 });
+        expect(progressValues).toContainEqual({ progress: 40 });
+        // immediate call + 2 future updates = 3 total
+        expect(listener).toHaveBeenCalledTimes(3);
+        unsubscribe();
+        resolve();
+      }, 10);
+    });
+  });
+
+  it("should allow subscribing after task has started and only receive future updates, in non immediate mode", () => {
+    const runner = createTaskRunnerRepository<string, RunningState>();
+
+    const key = "job-1";
+    const initialState = runner.getTaskRunnerStateNode(key);
+
+    if (initialState.type !== "idle") {
+      throw new Error("Expected initial state to be idle");
+    }
+
+    // Start the task first
+    const progressValues: RunningState[] = [];
+    const emitLaterRef: { current: (() => void) | null } = { current: null };
+    initialState.run(() => {
+      return new Observable<RunningState>((subscriber) => {
+        // Emit initial progress
+        subscriber.next({ progress: 10 });
+        subscriber.next({ progress: 20 });
+
+        // Store function to emit more progress after subscription
+        emitLaterRef.current = () => {
+          subscriber.next({ progress: 30 });
+          subscriber.next({ progress: 40 });
+        };
+        // Don't complete - keep observable alive
+      });
+    });
+
+    // Verify task is running
+    const runningState = runner.getTaskRunnerStateNode(key);
+    expect(runningState.type).toBe("running");
+    if (runningState.type === "running") {
+      expect(runningState.data![0].progress).toBe(20);
+    }
+
+    // Now subscribe AFTER the task has started
+    const listener = vi.fn(
+      (state: {
+        type: "idle" | "running";
+        data?: [RunningState] | null;
+        error?: [unknown] | null;
+      }) => {
+        if (state.type === "running" && state.data) {
+          progressValues.push(state.data[0]);
+        }
+      }
+    );
+
+    const unsubscribe = runner.listen(key, listener);
+
+    // With immediate: true, should receive current state immediately
+    expect(listener).not.toHaveBeenCalled();
+    expect(progressValues.length).toBe(0);
+    // Should have received the last emitted progress (20) immediately
+
+    // Now emit more progress after subscription
+    if (emitLaterRef.current) {
+      emitLaterRef.current();
+    }
+
+    // Wait a bit for updates to propagate
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        // Should have received future updates (30, 40)
+        expect(progressValues).toContainEqual({ progress: 30 });
+        expect(progressValues).toContainEqual({ progress: 40 });
+        // immediate call + 2 future updates = 3 total
+        expect(listener).toHaveBeenCalledTimes(2);
+        unsubscribe();
+        resolve();
+      }, 10);
+    });
+  });
+
+  it("should allow subscribing after task has errored and receive error state immediately, in immediate mode", () => {
+    const runner = createTaskRunnerRepository<string, RunningState>();
+
+    const key = "job-1";
+    const initialState = runner.getTaskRunnerStateNode(key);
+
+    if (initialState.type !== "idle") {
+      throw new Error("Expected initial state to be idle");
+    }
+
+    const testError = new Error("Task failed");
+    // Start the task and immediately error it out
+    initialState.run(() => {
+      return new Observable<RunningState>((subscriber) => {
+        // Error immediately
+        subscriber.error(testError);
+      });
+    });
+
+    // Wait a bit to ensure error has been processed
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        // Verify task is back to idle with error
+        const idleState = runner.getTaskRunnerStateNode(key);
+        expect(idleState.type).toBe("idle");
+        if (idleState.type === "idle") {
+          expect(idleState.error).toEqual(null);
+        }
+
+        // Now subscribe AFTER the task has errored
+        const listener = vi.fn(
+          (_state: {
+            type: "idle" | "running";
+            data?: [RunningState] | null;
+            error?: [unknown] | null;
+          }) => {
+            // Track error states
+          }
+        );
+
+        const unsubscribe = runner.listen(key, listener, true);
+
+        // With immediate: true, should receive current state (idle with error) immediately
+        expect(listener).toHaveBeenCalledTimes(1);
+        const receivedState = listener.mock.calls[0][0];
+        expect(receivedState.type).toBe("idle");
+        if (receivedState.type === "idle") {
+          expect(receivedState.error).toEqual(null);
+        }
+
+        unsubscribe();
+        resolve();
+      }, 10);
+    });
+  });
+
+  it("should allow subscribing after task has errored and not receive error state immediately, in non immediate mode", () => {
+    const runner = createTaskRunnerRepository<string, RunningState>();
+
+    const key = "job-1";
+    const initialState = runner.getTaskRunnerStateNode(key);
+
+    if (initialState.type !== "idle") {
+      throw new Error("Expected initial state to be idle");
+    }
+
+    const testError = new Error("Task failed");
+    // Start the task and immediately error it out
+    initialState.run(() => {
+      return new Observable<RunningState>((subscriber) => {
+        // Error immediately
+        subscriber.error(testError);
+      });
+    });
+
+    // Wait a bit to ensure error has been processed
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        // Verify task is back to idle with error
+        const idleState = runner.getTaskRunnerStateNode(key);
+        expect(idleState.type).toBe("idle");
+
+        if (idleState.type === "idle") {
+          expect(idleState.error).toEqual(null);
+        }
+
+        // Now subscribe AFTER the task has errored
+        const listener = vi.fn(
+          (_state: {
+            type: "idle" | "running";
+            data?: [RunningState] | null;
+            error?: [unknown] | null;
+          }) => {
+            // Track error states
+          }
+        );
+
+        const unsubscribe = runner.listen(key, listener);
+
+        // With immediate: false, should not receive current state immediately
+        expect(listener).not.toHaveBeenCalled();
+
+        unsubscribe();
+        resolve();
+      }, 10);
+    });
+  });
+});

--- a/src/utils/task-runner-repository/task-runner-repository.ts
+++ b/src/utils/task-runner-repository/task-runner-repository.ts
@@ -1,0 +1,184 @@
+import type { Observable } from "rxjs";
+import { pubSub, pubSubRegistry } from "../pub-sub/pub-sub";
+import { firstFromSubjectSync } from "../subject/subject";
+
+/**
+ * Represents an idle state for a job.
+ */
+type Idle = {
+  type: "idle";
+  error: [unknown] | null;
+};
+
+/**
+ * Represents a running state for a job.
+ */
+type Running<Status> = {
+  type: "running";
+  data: [Status] | null;
+};
+
+/**
+ * A function that initiates a job, returning an observable which will signal
+ * any updates from the job being run.
+ */
+export type Task<Key, RunningState> = (options: {
+  jobKey: Key;
+  abortSignal: AbortSignal;
+}) => Observable<RunningState>;
+
+// Considering that we have effectively a 2-state automata, and each state is a
+// node in a graph, then I might as well call them "nodes".
+
+type IdleNode<Key, RunningState> = Idle & {
+  run: (
+    runJob: Task<Key, RunningState>,
+    abortController?: AbortController
+  ) => void;
+};
+type RunningNode<RunningState> = Running<RunningState> & {
+  stop: (reason?: [unknown] | null) => void;
+};
+
+type JobState<RunningState> = Idle | Running<RunningState>;
+
+type MachineNode<Key, RunningState> =
+  | IdleNode<Key, RunningState>
+  | RunningNode<RunningState>;
+
+/**
+ * Creates a new job runner for a specific class of jobs.
+ *
+ * For example, in the context of this repo, a job runner could—for example—
+ * focus on prompt completion tasks.
+ *
+ * Usage:
+ *
+ *     const myJob: JobRunner<unknown, unknown> = (abortSignal): Observable<void> => {
+ *       signal.addEventListener('abort', () => {
+ *         // Cleanup here.
+ *         //
+ *         // The job should have been stopped already.
+ *       });
+ *
+ *
+ *
+ *       // For a while
+ *       progress({ type: 'some progress' });
+ *
+ *       // Eventually
+ *       stop({ reason: 'done' });
+ *     }
+ *
+ *     const runner = jobRunner<string, unknown, unknown>();
+ *
+ *     let state = runner.getState('foo');
+ *
+ *     if (state.type === 'idle') {
+ *       state.start(myJob, new AbortController());
+ *     }
+ *
+ *     // Perhaps later.
+ *
+ *     state = runner.getState('foo');
+ *
+ *     if (state.type === 'running' && someCondition(state)) {
+ *       state.stop();
+ *     }
+ * @returns an object to get the current state, as well as listen on job status
+ *   change events.
+ */
+export function createTaskRunnerRepository<Key, RunningState>() {
+  const ps = pubSub<Key, JobState<RunningState>>(
+    pubSubRegistry<Key, JobState<RunningState>>({
+      initialValue: () => ({
+        type: "idle",
+        error: null,
+      }),
+      shouldCleanup: (_, lastEmittedValue): boolean => {
+        return lastEmittedValue.type !== "running";
+      },
+    })
+  );
+
+  const stop = (key: Key, stoppedState: [unknown] | null = null) => {
+    if (currentJobs.has(key)) {
+      currentJobs.get(key)!.abortController.abort();
+    }
+    ps.next(key, { type: "idle", error: stoppedState });
+    currentJobs.delete(key);
+  };
+
+  const currentJobs = new Map<Key, { abortController: AbortController }>();
+
+  return {
+    getTaskRunnerStateNode: (key: Key): MachineNode<Key, RunningState> => {
+      const node = firstFromSubjectSync(ps.subject(key));
+
+      if (node === null) throw new Error("No first value available");
+      const status = node[0];
+
+      switch (status.type) {
+        case "idle":
+          return (() => {
+            let hasRun = false;
+            return {
+              type: "idle",
+              error: status.error,
+              run: (
+                task: Task<Key, RunningState>,
+                abortController = new AbortController()
+              ) => {
+                if (hasRun) return;
+                hasRun = true;
+
+                const node = firstFromSubjectSync(ps.subject(key));
+                if (node !== null && node[0].type === "running") return;
+
+                currentJobs.set(key, {
+                  abortController,
+                });
+                ps.next(key, { type: "running", data: null });
+
+                task({
+                  jobKey: key,
+                  abortSignal: abortController.signal,
+                }).subscribe({
+                  next: (data) => {
+                    ps.next(key, { type: "running", data: [data] });
+                  },
+                  complete: () => {
+                    stop(key);
+                  },
+                  error: (error: unknown) => {
+                    stop(key, [error]);
+                  },
+                });
+              },
+            };
+          })();
+        case "running":
+          return (() => {
+            let hasStopped = false;
+
+            return {
+              type: "running",
+              data: status.data,
+              stop: (data: [unknown] | null = null) => {
+                if (hasStopped) return;
+                hasStopped = true;
+
+                const node = firstFromSubjectSync(ps.subject(key));
+                if (node !== null && node[0].type === "idle") return;
+
+                stop(key, data);
+              },
+            };
+          })();
+      }
+
+      const _: never = status;
+    },
+    listen: ps.listen,
+  };
+}

--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -1,0 +1,32 @@
+import { expect, test, vi } from "vitest";
+import { gate } from "./utils";
+
+test("gate allows and blocks as expected", () => {
+  const g = gate();
+
+  const listenerA = vi.fn();
+  const listenerB = vi.fn();
+  const unsubscribeA = g.listen(listenerA);
+  g.listen(listenerB);
+
+  expect(listenerA).not.toHaveBeenCalled();
+  expect(listenerB).not.toHaveBeenCalled();
+
+  unsubscribeA();
+
+  g.open();
+
+  expect(listenerA).not.toHaveBeenCalled();
+  expect(listenerB).toHaveBeenCalledTimes(1);
+
+  g.open(); // second open is a no-op
+
+  expect(listenerB).toHaveBeenCalledTimes(1);
+
+  const lateListener = vi.fn();
+  const unsubscribeLate = g.listen(lateListener);
+
+  expect(lateListener).toHaveBeenCalledTimes(1);
+
+  unsubscribeLate();
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,12 +1,22 @@
-import { defineConfig } from "vite";
+import { defineConfig, type PluginOption } from "vite";
 import react from "@vitejs/plugin-react";
 import { logseqDevPlugin } from "./vite-plugins/logseq";
 import tailwindcss from "@tailwindcss/vite";
 
-export default defineConfig({
-  plugins: [tailwindcss({}), logseqDevPlugin(), react()],
-  build: {
-    target: "esnext",
-    minify: "esbuild",
-  },
+export default defineConfig(() => {
+  const plugins: PluginOption[] = [tailwindcss({})];
+
+  if (!process.env.VITEST) {
+    plugins.push(logseqDevPlugin());
+  }
+
+  plugins.push(react());
+
+  return {
+    plugins,
+    build: {
+      target: "esnext",
+      minify: "esbuild" as const,
+    },
+  };
 });


### PR DESCRIPTION
- [x] write even more test cases for job-runner.ts (specifically to test for behaviours with and without listeners). Document behaviours (such as the clearing out of idle state when no listeners were registered when stop)
- [x] actually integrate this new stuff
- [x] document all the dependencies that `JobRunner` is made of

Hopefully once all of this has been fixed, we can eventually tackle #57.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a task-runner repository with pub-sub to replace the job registry, migrate chat completion to it, and add RxJS/Vitest with extensive tests and build tweaks.
> 
> - **Core/Infrastructure**:
>   - **Task Runner Repository**: Add `utils/task-runner-repository` with pub-sub (`utils/pub-sub`) and resource registry (`utils/resource-registry`) building blocks plus `subject` utility; exposes `listen`/`getTaskRunnerStateNode` with idle/running state machine.
>   - **Completion Runners**: Add `services/completion-task-runners` and `services/chat-completion-tasks` (`simpleCompletion`) using the new runner pattern.
> - **App Integration**:
>   - Migrate `ChatThreadView` and `NewChatView` to use `completionTaskRunnerRepository` for starting/stopping runs and status; replace prior job-registry/chat-completion wiring.
>   - Update imports to `utils/utils` (moved helpers like `transformDashBulletPointsToStars`, `filterPropertyLines`, `gate`, etc.).
> - **Testing & Tooling**:
>   - Add Vitest and RxJS; create comprehensive tests for `subject`, `pub-sub`, `resource-registry`, and `task-runner-repository`.
>   - Vite config guards `logseqDevPlugin` under tests; add `test` script.
> - **Docs**:
>   - Add `architecture.md` documenting the task-runner repository and its dependencies.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5120d7e3c51f1ab2e16167b392fafebba0971177. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->